### PR TITLE
security: harden signoff-check workflow (pin actions, drop token perms, lock registry)

### DIFF
--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
 name: Check Signed-Off-By
 
 on:

--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -6,11 +6,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-# Least privilege for the default GITHUB_TOKEN. This workflow runs on
-# `pull_request_target`, so its token is created in the context of the base repo;
-# every step that reads the API, checks out code or posts the comment uses the
-# scoped GitHub App token generated below instead, so the default token needs no
-# permissions at all. Denying them removes it as an asset to any injected code.
 permissions: {}
 
 jobs:
@@ -19,10 +14,6 @@ jobs:
     name: Check Signed-Off-By
 
     steps:
-      # Allow bots that open PRs automatically (e.g. right after a merge) to
-      # bypass the Signed-Off-By check. We require BOTH the PR author AND the
-      # event sender to be bots, so a human editing a bot's PR from the web
-      # (a `synchronize` event whose sender is a user) is NOT allowed to bypass.
       - name: Determine bot bypass
         id: bot-check
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -6,6 +6,13 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Least privilege for the default GITHUB_TOKEN. This workflow runs on
+# `pull_request_target`, so its token is created in the context of the base repo;
+# every step that reads the API, checks out code or posts the comment uses the
+# scoped GitHub App token generated below instead, so the default token needs no
+# permissions at all. Denying them removes it as an asset to any injected code.
+permissions: {}
+
 jobs:
   signoff-check:
     runs-on: ubuntu-latest
@@ -18,7 +25,7 @@ jobs:
       # (a `synchronize` event whose sender is a user) is NOT allowed to bypass.
       - name: Determine bot bypass
         id: bot-check
-        uses: actions/github-script@v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -43,19 +50,30 @@ jobs:
 
       - name: Checkout
         if: steps.bot-check.outputs.bypass != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
           repository: InditexTech/cla-checker
+          # Do not leave the app token in the checkout's git config; no later step
+          # performs git operations, and the API/token uses below pass it explicitly.
+          persist-credentials: false
 
       - name: Install dependencies
         if: steps.bot-check.outputs.bypass != 'true'
-        run: npm install js-yaml handlebars
+        # Pin the direct dependencies to exact versions so a compromised or
+        # unexpected newer release cannot enter this privileged job. (Follow-up:
+        # a committed package-lock.json + `npm ci` would also pin transitives.)
+        #
+        # Force the public npm registry explicitly: this privileged job must
+        # resolve these packages from a known source, never from a private
+        # registry that a stray .npmrc, an org runner default or an
+        # NPM_CONFIG_REGISTRY value could otherwise redirect it to.
+        run: npm install --no-save --registry=https://registry.npmjs.org/ js-yaml@4.1.0 handlebars@4.7.8
 
       - name: Collect PR Data
         id: collect-data
         if: steps.bot-check.outputs.bypass != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -65,7 +83,7 @@ jobs:
       - name: Check Signoffs
         id: check-signoffs
         if: steps.bot-check.outputs.bypass != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -76,7 +94,7 @@ jobs:
 
       - name: Generate PR Comment
         if: always() && steps.bot-check.outputs.bypass != 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |

--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -45,20 +45,10 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           repository: InditexTech/cla-checker
-          # Do not leave the app token in the checkout's git config; no later step
-          # performs git operations, and the API/token uses below pass it explicitly.
           persist-credentials: false
 
       - name: Install dependencies
         if: steps.bot-check.outputs.bypass != 'true'
-        # Pin the direct dependencies to exact versions so a compromised or
-        # unexpected newer release cannot enter this privileged job. (Follow-up:
-        # a committed package-lock.json + `npm ci` would also pin transitives.)
-        #
-        # Force the public npm registry explicitly: this privileged job must
-        # resolve these packages from a known source, never from a private
-        # registry that a stray .npmrc, an org runner default or an
-        # NPM_CONFIG_REGISTRY value could otherwise redirect it to.
         run: npm install --no-save --registry=https://registry.npmjs.org/ js-yaml@4.1.0 handlebars@4.7.8
 
       - name: Collect PR Data


### PR DESCRIPTION
## Summary

Hardens the `signoff-check.yml` reusable workflow, which runs on **`pull_request_target`**, checks out **`InditexTech/cla-checker`** and executes its scripts under a privileged, base-repo token. This reduces the workflow's attack surface **without changing what it validates**.

| Change | Why |
|--------|-----|
| `permissions: {}` at the top level | The default `GITHUB_TOKEN` is never used — every step authenticates with the scoped GitHub **App** token. Stripping all scopes removes it as an asset to any injected code. |
| Pin `actions/github-script` (v6→v7) and `actions/checkout` (v5) to full commit SHAs | A mutable tag on a privileged `pull_request_target` workflow is a supply-chain risk (a moved tag = silent code swap). |
| `persist-credentials: false` on checkout | The App token is passed explicitly to every consumer, so it need not linger in the runner's git config. |
| Pin npm direct deps to exact versions (`js-yaml@4.1.0`, `handlebars@4.7.8`, `--no-save`) | An unexpected newer release cannot enter this privileged job. |
| Force the public registry (`--registry=https://registry.npmjs.org/`) | This privileged job must resolve `js-yaml`/`handlebars` from a **known source** — a stray `.npmrc`, an org runner default, or an `NPM_CONFIG_REGISTRY` value must not be able to redirect it to a **private registry** serving a tampered package. |

## What is deliberately unchanged
- The checked-out repository (`InditexTech/cla-checker`), the GitHub App identity, the bot-bypass logic and the sign-off validation itself are untouched. This is purely a hardening of *how* the workflow runs, not *what* it checks.
- The workflow still checks out a **trusted** repo (never the fork), so no attacker code executes — this PR defends the token/dependency surface, not an RCE.

## Pairs with
`InditexTech/cla-checker#5` — hardens the **scripts** this workflow runs (author-spoof sign-off bypass, commit-list truncation, comment Markdown injection). Order-independent; neither PR requires the other to merge first (deps are pinned inline, not via a lockfile).

## Follow-up (out of scope here)
A committed `package-lock.json` + `npm ci` would also pin **transitive** deps. Left as a follow-up to avoid coupling this PR's merge order to a lockfile landing in cla-checker.

---
Please review & approve — I have **not** self-approved or merged.